### PR TITLE
Refactors, improved syntax highlighting and tweaked indentation

### DIFF
--- a/mercury-font-lock.el
+++ b/mercury-font-lock.el
@@ -1,0 +1,195 @@
+;;; mercury-font-lock.el --- Font locking module for Mercury mode.
+
+;; Copyright (C) 2019 Ludvig Böklin
+
+;; Authors: Ludvig Böklin
+;; URL: https://github.com/lboklin/metal-mercury-mode
+
+;; This file is not part of GNU Emacs.
+
+;; This file is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;; Code:
+(require 'font-lock)
+
+(defgroup mercury-font-lock nil
+  "Font locking for Mercury code."
+  :group 'faces)
+
+(defface mercury-font-lock-operators
+  '((t :inherit font-lock-builtin-face))
+  "The default face used to highlight operators inside expressions."
+  :group 'mercury-font-lock)
+
+(defcustom mercury-font-lock-operators-face 'mercury-font-lock-operators
+  "The face used to highlight operators inside expressions.
+To disable this highlighting, set this to nil."
+  :type '(choice (const nil)
+                 face)
+  :group 'mercury-font-lock)
+
+(defface mercury-font-lock-multiline-list-delimiters
+  '((t :inherit font-lock-keyword-face))
+  "The default face used to highlight brackets and commas in multiline lists."
+  :group 'mercury-font-lock)
+
+(defcustom mercury-font-lock-multiline-list-delimiters-face 'mercury-font-lock-multiline-list-delimiters
+  "The face used to highlight brackets and commas in multilist lists.
+To disable this highlighting, set this to nil."
+  :type '(choice (const nil)
+                 face)
+  :group 'mercury-font-lock)
+
+(defconst mercury--keywords
+  '("where" "if" "then" "else"
+    ;; declarations
+    "type" "solver" "pred" "func" "inst" "mode" "typeclass"
+    "instance" "pragma" "promise" "initialise" "finalise"
+    "mutable" "module" "interface" "implementation"
+    "import_module" "use_module" "include_module" "end_module"
+    ;; inst names
+    "any" "bound" "bound_unique"
+    "clobbered" "clobbered_any"
+    "free" "ground" "mostly_clobbered"
+    "mostly_unique" "mostly_unique_any"
+    "not_reached" "unique" "unique_any"
+    "any_func" "any_pred" "is"
+    ;; determinism
+    "erroneous" "failure" "det" "semidet" "nondet"
+    "multi" "cc_nondet" "cc_multi"
+    )
+  "Reserved keywords.")
+
+(defconst mercury--regexp-keywords
+  (regexp-opt mercury--keywords 'symbols)
+  "A regular expression representing the reserved keywords.")
+
+(defconst mercury--font-lock-keywords
+  (cons mercury--regexp-keywords font-lock-keyword-face)
+  "Highlighting for keywords.")
+
+(defconst mercury--regexp-operators
+  "[-+*/\\\\<>=:@^&.;,]+"
+  "A regular expression representing operators inside expressions.")
+
+(defvar mercury--syntax-table
+  (let ((st (make-syntax-table)))
+    (modify-syntax-entry ?%  "<" st)
+    (modify-syntax-entry ?\n ">" st)
+
+    ;; matching parens
+    (modify-syntax-entry ?\( "()" st)
+    (modify-syntax-entry ?\) ")(" st)
+    (modify-syntax-entry ?\[ "(]" st)
+    (modify-syntax-entry ?\] ")[" st)
+    (modify-syntax-entry ?\{ "(}" st)
+    (modify-syntax-entry ?\} "){" st)
+
+    ;; " and ' for literal strings
+    (modify-syntax-entry ?\" "\"\"" st)
+    (modify-syntax-entry ?\' "\"'" st)
+    (modify-syntax-entry ?\\ "/" st)
+
+    ;; operator chars get punctuation syntax
+    (mapc #'(lambda (ch) (modify-syntax-entry ch "." st))
+          mercury--regexp-operators)
+
+    ;; _ can be part of names, so give it symbol constituent syntax
+    (modify-syntax-entry ?_ "_" st)
+    st))
+
+(defconst mercury--regexp-function
+  "\\(^\\|func \\|pred \\|mode \\)\\(\\<[a-z][0-9A-Za-z_]*\\)"
+  "A regular expression representing function names.")
+
+(defconst mercury--font-lock-functions
+  (cons mercury--regexp-function '(2 font-lock-function-name-face))
+  "Highlighting for function names.")
+
+(defconst mercury--regexp-variable
+  "\\<[_A-Z][0-9A-Za-z_]*"
+  "A regular expression representing variable names.")
+
+(defconst mercury--font-lock-variables
+  (cons mercury--regexp-variable font-lock-variable-name-face)
+  "Highlighting for function names.")
+
+(defconst mercury--font-lock-operators
+  (cons mercury--regexp-operators 'mercury-font-lock-operators-face)
+  "Highlighting for operators inside expressions.")
+
+(defconst mercury--regexp-multiline-list-comma-closing-brackets
+  (concat "^[[:space:]]*" (regexp-opt '("," ";" "]" "}" ")") t))
+  "A regular expression representing separators and closing brackets in
+multiline lists, disjunctions, tuples and records.")
+
+(defconst mercury--font-lock-multiline-list-comma-closing-brackets
+  (cons mercury--regexp-multiline-list-comma-closing-brackets
+        '(1 mercury-font-lock-multiline-list-delimiters-face))
+  "Highlighting for separators and closing brackets in
+multiline lists, disjunctions, tuples and records.")
+
+(defun mercury--match-multiline-list-opening-bracket (limit)
+  "Highlighting search function for opening brackets in multiline lists, disjunctions and records.
+Also highlights opening brackets without a matching bracket."
+  (when (mercury--search-forward-opening-bracket limit)
+    (let ((opening (point))
+          (eol (line-end-position))
+          (closing (mercury--search-forward-closing-bracket)))
+      (if (or (= closing opening) (> closing eol))
+          (progn
+            (set-match-data (match-data))
+            (goto-char (+ 1 opening))
+            t)
+        (mercury--match-multiline-list-opening-bracket limit)))))
+
+(defun mercury--search-forward-opening-bracket (limit)
+  "Go to the next opening bracket up to LIMIT."
+  (if (search-forward-regexp (regexp-opt '("[" "{" "(")) limit t)
+      (progn
+        (backward-char)
+        t)))
+
+(defun mercury--search-forward-closing-bracket ()
+  "Go to the next matching bracket, assuming that the cursor is on an opening bracket."
+  (ignore-errors
+    (save-match-data
+      (forward-sexp)))
+  (point))
+
+(defconst mercury--font-lock-multiline-list-opening-brackets
+  '(mercury--match-multiline-list-opening-bracket (0 mercury-font-lock-multiline-list-delimiters-face))
+  "Highlighting for opening brackets in multiline lists and records.")
+
+(defconst mercury--font-lock-highlighting
+  (list (list (cons "%.*" 'font-lock-comment-face)
+              mercury--font-lock-keywords
+              (cons "\\(\\!\\)[[:upper:]$]+[[:lower:]_$]*" '(1 font-lock-keyword-face))
+              mercury--font-lock-functions
+              mercury--font-lock-variables
+              mercury--font-lock-multiline-list-comma-closing-brackets
+              mercury--font-lock-multiline-list-opening-brackets
+              mercury--font-lock-operators
+              )))
+        ;; nil nil))
+
+(defun turn-on-mercury-font-lock ()
+  "Turn on Mercury font lock."
+  (setq font-lock-multiline t)
+  (set-syntax-table mercury--syntax-table)
+  (set (make-local-variable 'font-lock-defaults) mercury--font-lock-highlighting))
+
+(provide 'mercury-font-lock)
+;;; mercury-font-lock.el ends here

--- a/mercury-font-lock.el
+++ b/mercury-font-lock.el
@@ -2,8 +2,9 @@
 
 ;; Copyright (C) 2019 Ludvig Böklin
 
-;; Authors: Ludvig Böklin
-;; URL: https://github.com/lboklin/metal-mercury-mode
+;; Author: Ludvig Böklin <ludvig.boklin@protonmail.com>
+;; Maintainer: Matthew Carter <m@ahungry.com>
+;; URL: https://github.com/ahungry/metal-mercury-mode
 
 ;; This file is not part of GNU Emacs.
 

--- a/mercury-font-lock.el
+++ b/mercury-font-lock.el
@@ -184,14 +184,17 @@ Also highlights opening brackets without a matching bracket."
                     '(1 font-lock-constant-face))
               mercury--font-lock-functions
               mercury--font-lock-variables
+
+              ;; types, modes and modules
               (cons (concat
-                     "\\<\\(?:::\\|[(,=]\\) *"
+                     "\\<\\(?:::\\|[({,=]\\) *"
                      "\\([[:lower:]][[:alpha:]_0-9]+\\)\\>")
                     '(1 font-lock-type-face))
               (cons (concat
                      "\\([[:lower:]][[:alpha:]_0-9]+\\)"
-                     "\\(?:::\\|[,)\\.]\\| is\\)")
+                     "\\(?:::\\| *[,})\\.]\\| is\\)")
                     '(1 font-lock-type-face))
+
               mercury--font-lock-multiline-list-comma-closing-brackets
               mercury--font-lock-multiline-list-opening-brackets
               mercury--font-lock-operators

--- a/mercury-font-lock.el
+++ b/mercury-font-lock.el
@@ -188,7 +188,7 @@ Also highlights opening brackets without a matching bracket."
 
               ;; types, modes and modules
               (cons (concat
-                     "\\<\\(?:::\\|[({,=]\\) *"
+                     "\\<\\(?:type\\|::\\|:\\|[({,=]\\) *"
                      "\\([[:lower:]][[:alpha:]_0-9]+\\)\\>")
                     '(1 font-lock-type-face))
               (cons (concat

--- a/mercury-font-lock.el
+++ b/mercury-font-lock.el
@@ -53,23 +53,45 @@ To disable this highlighting, set this to nil."
   :group 'mercury-font-lock)
 
 (defconst mercury--keywords
-  '("if" "then" "else" "not"
-    ;; declarations
-    "all" "some" "pred" "func"
-    "type" "solver" "inst" "mode" "typeclass" "instance"
-    "pragma" "promise" "initialise" "finalise"
-    "mutable" "module" "interface" "implementation"
-    "import_module" "use_module" "include_module" "end_module"
-    ;; inst names
-    "any" "bound" "bound_unique"
-    "clobbered" "clobbered_any"
-    "free" "ground" "mostly_clobbered"
-    "mostly_unique" "mostly_unique_any"
-    "not_reached" "unique" "unique_any"
-    "any_func" "any_pred" "is"
+  '(;; keywords taken from the language reference manual.
+    ;; allowed declarations
+    "type" "solver" "pred" "func" "inst" "mode" "typeclass"
+    "instance" "pragma" "promise" "initialise" "finalise"
+    "mutable" "module" "interface" "implementation" "import_module"
+    "use_module" "include_module" "end_module"
     ;; determinism
     "erroneous" "failure" "det" "semidet" "nondet"
     "multi" "cc_nondet" "cc_multi"
+    ;; reserved inst names
+    "=<" "any" "bound" "bound_unique" "clobbered" "clobbered_any"
+    "free" "ground" "is" "mostly_clobbered" "mostly_unique"
+    "mostly_unique_any" "not_reached" "unique" "unique_any"
+    ;; reserved mode names (excluding ones already included)
+    "=" ">>" "any_func" "any_pred"
+    ;; reserved operators (excluding ones already included)
+    "." "!" "!." "!:" "@" "^" "^" "event" ":" "‘op ‘" "**" "-" "\\"
+    "*" "/" "//" "<<" "div" "mod" "rem" "for" "+" "+" "++"
+    "-" "--" "/\\" "\\/" ".." ":=" "=^" "<" "=.." "=:="
+    "==" "=\\=" ">" ">=" "@<" "@=<" "@>" "@>=" "\\=" "\\=="
+    "~=" "and" "or" "impure" "semipure" "\\\\+"
+    "not" "when" "~" "<=" "<=>" "=>"
+    "all" "arbitrary" "atomic" "disable_warning" "disable_warnings"
+    "promise_equivalent_solutions" "promise_equivalent_solution_sets"
+    "promise_exclusive" "promise_exclusive_exhaustive"
+    "promise_exhaustive" "promise_impure" "promise_pure"
+    "promise_semipure" "require_complete_switch"
+    "require_switch_arms_det" "require_switch_arms_semidet"
+    "require_switch_arms_multi" "require_switch_arms_nondet"
+    "require_switch_arms_cc_multi" "require_switch_arms_cc_nondet"
+    "require_switch_arms_erroneous" "require_switch_arms_failure"
+    "require_det" "require_semidet"
+    "require_multi" "require_nondet" "require_cc_multi"
+    "require_cc_nondet" "require_erroneous" "require_failure"
+    "trace" "try" "some" "," "&" "->" ";" "or_else" "then" "if" "else"
+    "::" "==>" "where" "--->" "catch" "type" "solver" "catch_any"
+    "initialise" "initialize" "finalise" "finalize" "inst" "instance"
+    "mode" "module" "pragma" "promise" "rule" "typeclass" "use_module"
+    "-->" ":-" "?-"
     )
   "Reserved keywords.")
 

--- a/mercury-font-lock.el
+++ b/mercury-font-lock.el
@@ -103,36 +103,6 @@ To disable this highlighting, set this to nil."
   (cons mercury--regexp-keywords font-lock-keyword-face)
   "Highlighting for keywords.")
 
-(defconst mercury--regexp-operators
-  "[-+*/\\\\<>=:@^&.;,]+"
-  "A regular expression representing operators inside expressions.")
-
-(defvar mercury--syntax-table
-  (let ((st (make-syntax-table)))
-    (modify-syntax-entry ?%  "<" st)
-    (modify-syntax-entry ?\n ">" st)
-
-    ;; matching parens
-    (modify-syntax-entry ?\( "()" st)
-    (modify-syntax-entry ?\) ")(" st)
-    (modify-syntax-entry ?\[ "(]" st)
-    (modify-syntax-entry ?\] ")[" st)
-    (modify-syntax-entry ?\{ "(}" st)
-    (modify-syntax-entry ?\} "){" st)
-
-    ;; " and ' for literal strings
-    (modify-syntax-entry ?\" "\"\"" st)
-    (modify-syntax-entry ?\' "\"'" st)
-    (modify-syntax-entry ?\\ "/" st)
-
-    ;; operator chars get punctuation syntax
-    (mapc #'(lambda (ch) (modify-syntax-entry ch "." st))
-          mercury--regexp-operators)
-
-    ;; _ can be part of names, so give it symbol constituent syntax
-    (modify-syntax-entry ?_ "_" st)
-    st))
-
 (defconst mercury--regexp-function
   "\\(^\\|func \\|pred \\|mode \\)\\(\\<[a-z][0-9A-Za-z_]*\\)"
   "A regular expression representing function names.")
@@ -148,6 +118,10 @@ To disable this highlighting, set this to nil."
 (defconst mercury--font-lock-variables
   (cons mercury--regexp-variable font-lock-variable-name-face)
   "Highlighting for function names.")
+
+(defconst mercury--regexp-operators
+  "[-+*/\\\\<>=:@^&.;,]+"
+  "A regular expression representing operators inside expressions.")
 
 (defconst mercury--font-lock-operators
   (cons mercury--regexp-operators 'mercury-font-lock-operators-face)
@@ -227,7 +201,6 @@ Also highlights opening brackets without a matching bracket."
 (defun turn-on-mercury-font-lock ()
   "Turn on Mercury font lock."
   (setq font-lock-multiline t)
-  (set-syntax-table mercury--syntax-table)
   (set (make-local-variable 'font-lock-defaults) mercury--font-lock-highlighting))
 
 (provide 'mercury-font-lock)

--- a/mercury-font-lock.el
+++ b/mercury-font-lock.el
@@ -53,10 +53,11 @@ To disable this highlighting, set this to nil."
   :group 'mercury-font-lock)
 
 (defconst mercury--keywords
-  '("where" "if" "then" "else"
+  '("if" "then" "else" "not"
     ;; declarations
-    "type" "solver" "pred" "func" "inst" "mode" "typeclass"
-    "instance" "pragma" "promise" "initialise" "finalise"
+    "all" "some" "pred" "func"
+    "type" "solver" "inst" "mode" "typeclass" "instance"
+    "pragma" "promise" "initialise" "finalise"
     "mutable" "module" "interface" "implementation"
     "import_module" "use_module" "include_module" "end_module"
     ;; inst names
@@ -176,9 +177,25 @@ Also highlights opening brackets without a matching bracket."
 (defconst mercury--font-lock-highlighting
   (list (list (cons "%.*" 'font-lock-comment-face)
               mercury--font-lock-keywords
-              (cons "\\(\\!\\)[[:upper:]$]+[[:lower:]_$]*" '(1 font-lock-keyword-face))
+              (cons "\\(\\!\\)[[:upper:]$]+[[:lower:]_$]*" ;; e.g. !IO
+                    '(1 font-lock-keyword-face))
+              (cons (concat
+                     "\\<"
+                     "\\(0[box]?[0-9][0-9_]*" ;; int literals
+                     "\\|[0-9]+\\(\\.[0-9]+\\(e\\([+-][0-9]+\\)?\\)?\\)?" ;; float literals
+                     "\\)"
+                     "\\>")
+                    '(1 font-lock-constant-face))
               mercury--font-lock-functions
               mercury--font-lock-variables
+              (cons (concat
+                     "\\<\\(?:::\\|[(,=]\\) *"
+                     "\\([[:lower:]][[:alpha:]_0-9]+\\)\\>")
+                    '(1 font-lock-type-face))
+              (cons (concat
+                     "\\([[:lower:]][[:alpha:]_0-9]+\\)"
+                     "\\(?:::\\|[,)\\.]\\| is\\)")
+                    '(1 font-lock-type-face))
               mercury--font-lock-multiline-list-comma-closing-brackets
               mercury--font-lock-multiline-list-opening-brackets
               mercury--font-lock-operators

--- a/mercury-indentation.el
+++ b/mercury-indentation.el
@@ -82,15 +82,6 @@ set and deleted as if they were real tabs."
   (interactive)
   (mercury-indentation-mode t))
 
-
-;;----------------------------------------------------------------------------
-;; UI starts here
-
-;; TODO
-
-;; ------------------------------
-;; Parser starts here
-
 (defun mercury-indentation-indent-line ()
   "Indent the current line as mercury code."
   (interactive)

--- a/mercury-indentation.el
+++ b/mercury-indentation.el
@@ -1,0 +1,281 @@
+;;; mercury-indentation.el --- indentation module for Mercury Mode -*- lexical-binding: t -*-
+
+;; Copyright (C) 2013-2019  Kristof Bastiaensen, Gergely Risko, Ludvig Böklin
+
+;; Author: Kristof Bastiaensen <kristof.bastiaensen@vleeuwen.org>
+;; Author: Gergely Risko <errge@nilcons.com>
+;; Author: Ludvig Böklin <ludvig.boklin@protonmail.com>
+;; Keywords: indentation mercury
+;; URL: https://github.com/lboklin/metal-mercury-mode
+
+;; This file is not part of GNU Emacs.
+
+;; This file is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Installation:
+;;
+;; To turn indentation on for all Mercury buffers under Mercury mode add
+;; this to your configuration file:
+;;
+;;     (add-hook metal-mercury-mode-hook 'mercury-indentation-mode)
+;;
+;; Otherwise, call `mercury-indentation-mode'.
+
+(require 'cl-lib)
+
+;;; Code:
+;;;###autoload
+(defgroup mercury-indentation nil
+  "Mercury indentation."
+  :link '(custom-manual "(metal-mercury-mode)Indentation")
+  :group 'mercury
+  :prefix "mercury-indentation-")
+
+(defvar mercury-indentation-default-tab-width 2)
+
+(defcustom mercury-indentation-electric-flag nil
+  "Non-nil means insertion of some characters may auto reindent the line.
+If the variable `electric-indent-mode' is non-nil then this variable is
+overridden."
+  :type 'symbol
+  :group 'mercury-indentation)
+(make-variable-buffer-local 'mercury-indentation-electric-flag)
+
+(defvar mercury-indentation-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "RET") #'newline-and-indent)
+    map)
+  "Keymap for `mercury-indentation-mode'.")
+
+
+;;;###autoload
+(define-minor-mode mercury-indentation-mode
+  "Mercury indentation mode that deals with the layout rule.
+It rebinds RET, DEL and BACKSPACE, so that indentations can be
+set and deleted as if they were real tabs."
+  :keymap mercury-indentation-mode-map
+  (kill-local-variable 'indent-line-function)
+  (kill-local-variable 'indent-region-function)
+
+  (when mercury-indentation-mode
+    (setq-local indent-line-function #'mercury-indentation-indent-line)
+    (setq-local indent-region-function #'mercury-indentation-indent-region)))
+
+;;;###autoload
+(defun turn-on-mercury-indentation ()
+  "Turn on the mercury-indentation minor mode."
+  (interactive)
+  (mercury-indentation-mode t))
+
+
+;;----------------------------------------------------------------------------
+;; UI starts here
+
+(defun mercury-indentation-current-indentation ()
+  "Column position of first non-whitespace character in current line."
+  (save-excursion
+    (beginning-of-line)
+    (skip-syntax-forward "-")
+    (current-column)))
+
+(defun mercury-indentation-newline-and-indent ()
+  "Insert newline and indent"
+  (interactive "*")
+  ;;  - save the current column
+  (let ((ci (mercury-indentation-current-indentation)))
+    ;; - jump to the next line and reindent to at the least same level
+    (delete-horizontal-space)
+    (newline)
+    ;; (let ((indentations (or (mercury-indentation-find-indentations)
+    ;;                         '(0))))
+    (let ((indentations '(0)))
+      (mercury-indentation-reindent-to
+       (mercury-indentation-next-indentation (- ci 1) indentations 'nofail)
+       'move))))
+
+(defun mercury-indentation-next-indentation (col indentations &optional nofail)
+  "Find the leftmost indentation which is greater than COL.
+Indentations are taken from INDENTATIONS, which should be a
+list.  Return the last indentation if there are no bigger ones and
+NOFAIL is non-NIL."
+  (when (null indentations)
+    (error "mercury-indentation-next-indentation called with empty list"))
+  (or (cl-find-if (lambda (i) (> i col)) indentations)
+      (when nofail
+        (car (last indentations)))))
+
+(defun mercury-indentation-previous-indentation (col indentations &optional nofail)
+  "Find the rightmost indentation less than COL from INDENTATIONS.
+When no indentations are less than COL, return the rightmost indentation
+if NOFAIL is non-nil, or nil otherwise."
+  (when (null indentations)
+    (error "mercury-indentation-previous-indentation called with empty list"))
+  (let ((rev (reverse indentations)))
+    (or (cl-find-if (lambda (i) (< i col)) rev)
+        (when nofail
+          (car rev)))))
+
+
+;; ------------------------------
+;; Parser starts here
+
+(defun mercury-indentation-indent-line ()
+  "Indent the current line as mercury code."
+  (interactive)
+  (beginning-of-line)
+  (if (bobp)
+      (indent-line-to 0) ; Check for rule 1
+    (let ((not-indented t) cur-indent)
+      ;; Check for rule 2 - End of a block (unindent)
+      (if (looking-at "^[ \t]*\\(;.*\\|),?\\|then.*\\|else.*\\)")
+          (progn
+            (let ((undo-mult 1))
+              (save-excursion
+                (when (looking-at "^[\t ]*),?") ;; on closing paren
+                  (progn
+                    (when (looking-at "[\t ]*\\(if\\|then\\|else\\).*$")
+                      (message (concat "looking at " (thing-at-point 'line t)))
+                      (setq undo-mult 2)))))
+              ;; Step back a line and check indent level
+              (save-excursion
+                (forward-line -1)
+                ;; if not inline (because when inline we're not yet indented) or open paren, unindent,
+                ;; otherwise do not change
+                (if (or (not (looking-at (concat
+                                          "^[\t ]*"
+                                          "\\(("
+                                          "\\|;"
+                                          "\\|\\<if\\>"
+                                          "\\|\\<then\\>"
+                                          "\\|\\<else\\>"
+                                          "\\)"
+                                          ".+$")))
+                        (and (looking-at "^[\t ]*(.+$")
+                             (not (parens-match '> (thing-at-point 'line t)))))
+                    (progn
+                      (message (thing-at-point 'line t))
+                      (message (concat
+                                "prev line was neither inline thing nor unmatched open paren: "
+                                (thing-at-point 'line t)))
+                      (setq cur-indent
+                            (- (current-indentation)
+                               (* undo-mult mercury-indentation-default-tab-width))))
+                  (progn
+                    (message (concat
+                              "prev line was inline thing or unmatched open paren: "
+                              (thing-at-point 'line t)))
+                    (setq undo-mult 1)
+                    (setq cur-indent (current-indentation)))))
+              (if (< cur-indent 0)
+                  (setq cur-indent 0))
+              ))
+        (save-excursion
+          (while not-indented ;; While loop backtracks up to last indent match
+            (forward-line -1)
+            (if (looking-at ".*\\. *$") ; Check for rule 3
+                (progn
+                  (message (thing-at-point 'line t))
+                  (setq cur-indent 0)
+                  (setq not-indented nil))
+              ;; Check for rule 4
+              ;; if previous line was an ;, if/then/else, opening/closing paren, = or :-,
+              ;; then if close paren, unindent, else indent.
+              (let ((line (replace-regexp-in-string "\".*\"" "" (thing-at-point 'line t))))
+                (if (or (string-match (concat "^[ \t]*"
+                                            "\\(;"
+                                            "\\|.*\\<if\\>"
+                                            "\\|.*\\<then\\>"
+                                            "\\|.*\\<else\\>"
+                                            "\\)"
+                                            ".*$")
+                                    line)
+                      (parens-match '> line)
+                      (and (parens-match '< line)
+                           (not (string-match "^[\t ]*),?" line)))
+                      (string-match (concat "^.*"
+                                            "\\(:-"
+                                            "\\|="
+                                            "\\)"
+                                            " *$")
+                                    line))
+                    (progn
+                      ;; if last line was closing (but not ending a conjunction), unindent,
+                      ;; else indent.
+                      (if (parens-match '< line)
+                          (progn
+                            (message "unindent because unmatched ) on prev line")
+                            (if (string-match "^[\t ]*),?" line)
+                                (setq cur-indent (current-indentation))
+                              (setq cur-indent
+                                  (- (current-indentation)
+                                     mercury-indentation-default-tab-width)))
+                            (setq not-indented nil))
+                        (progn
+                          (message (concat "indent because of indent starter: " line))
+                          (setq cur-indent
+                                (+ (current-indentation)
+                                   mercury-indentation-default-tab-width))
+                          (setq not-indented nil))
+                        ))
+                  ;; if nothing in particular was found on previous line
+                  ;; but not commented or empty, do not change indent.
+                  (when (not (string-match "^[\t ]*\\(%\\|\\)$" line))
+                    (progn
+                      (message "retain indentation")
+                      (setq cur-indent
+                            (current-indentation))
+                      (setq not-indented nil))))
+                (if (bobp) ; Check for rule 5
+                    (progn
+                      (message "bobp")
+                      (setq not-indented nil))))))))
+      (if (> cur-indent 0)
+          (indent-line-to cur-indent)
+        (indent-line-to 0)))))
+
+(defun is-indent-starter (str)
+  "Return t if STR is an indentation starter."
+  (or (parens-match '> str)
+      (string-match (concat "^[ \t]*"
+                            "\\(;"
+                            "\\|.*if"
+                            "\\|.*then"
+                            "\\|.*else"
+                            "\\)"
+                            ".*$")
+                    str)
+      (string-match (concat "^.*"
+                            "\\(:-"
+                            "\\|="
+                            "\\)"
+                            " *$")
+                    str)))
+
+(defun parens-match (comp str)
+  "Return result comparing with COMP number of opening parens with closing in STR."
+  (funcall comp
+           (length (matches-in-string "(" str))
+           (length (matches-in-string ")" str))))
+
+(defun matches-in-string (regex str)
+  "Return all occurrences of REGEX in STR."
+  (-filter #'(lambda (x) (not (eq "" x)))
+           (split-string str regex)))
+
+
+(provide 'mercury-indentation)
+
+;; mercury-indentation.el ends here

--- a/mercury-indentation.el
+++ b/mercury-indentation.el
@@ -37,6 +37,7 @@
 ;; Otherwise, call `mercury-indentation-mode'.
 
 (require 'cl-lib)
+(require 'dash)
 
 ;;; Code:
 ;;;###autoload
@@ -73,8 +74,7 @@ set and deleted as if they were real tabs."
   (kill-local-variable 'indent-region-function)
 
   (when mercury-indentation-mode
-    (setq-local indent-line-function #'mercury-indentation-indent-line)
-    (setq-local indent-region-function #'mercury-indentation-indent-region)))
+    (setq-local indent-line-function #'mercury-indentation-indent-line)))
 
 ;;;###autoload
 (defun turn-on-mercury-indentation ()
@@ -192,36 +192,16 @@ set and deleted as if they were real tabs."
           (indent-line-to cur-indent)
         (indent-line-to 0)))))
 
-(defun is-indent-starter (str)
-  "Return t if STR is an indentation starter."
-  (or (parens-match '> str)
-      (string-match (concat "^[ \t]*"
-                            "\\(;"
-                            "\\|.*if"
-                            "\\|.*then"
-                            "\\|.*else"
-                            "\\)"
-                            ".*$")
-                    str)
-      (string-match (concat "^.*"
-                            "\\(:-"
-                            "\\|="
-                            "\\)"
-                            " *$")
-                    str)))
-
 (defun parens-match (comp str)
   "Return result comparing with COMP number of opening parens with closing in STR."
-  (funcall comp
-           (length (matches-in-string "(" str))
-           (length (matches-in-string ")" str))))
-
-(defun matches-in-string (regex str)
-  "Return all occurrences of REGEX in STR."
-  (-filter #'(lambda (x) (not (eq "" x)))
-           (split-string str regex)))
-
+  (let
+      ((matches-in-string #'(lambda (regex str)
+                              (-filter #'(lambda (x) (not (eq "" x)))
+                                       (split-string str regex)))))
+    (funcall comp
+             (length (funcall matches-in-string "(" str))
+             (length (funcall matches-in-string ")" str)))))
 
 (provide 'mercury-indentation)
 
-;; mercury-indentation.el ends here
+;;; mercury-indentation.el ends here

--- a/mercury-indentation.el
+++ b/mercury-indentation.el
@@ -84,50 +84,7 @@ set and deleted as if they were real tabs."
 ;;----------------------------------------------------------------------------
 ;; UI starts here
 
-(defun mercury-indentation-current-indentation ()
-  "Column position of first non-whitespace character in current line."
-  (save-excursion
-    (beginning-of-line)
-    (skip-syntax-forward "-")
-    (current-column)))
-
-(defun mercury-indentation-newline-and-indent ()
-  "Insert newline and indent"
-  (interactive "*")
-  ;;  - save the current column
-  (let ((ci (mercury-indentation-current-indentation)))
-    ;; - jump to the next line and reindent to at the least same level
-    (delete-horizontal-space)
-    (newline)
-    ;; (let ((indentations (or (mercury-indentation-find-indentations)
-    ;;                         '(0))))
-    (let ((indentations '(0)))
-      (mercury-indentation-reindent-to
-       (mercury-indentation-next-indentation (- ci 1) indentations 'nofail)
-       'move))))
-
-(defun mercury-indentation-next-indentation (col indentations &optional nofail)
-  "Find the leftmost indentation which is greater than COL.
-Indentations are taken from INDENTATIONS, which should be a
-list.  Return the last indentation if there are no bigger ones and
-NOFAIL is non-NIL."
-  (when (null indentations)
-    (error "mercury-indentation-next-indentation called with empty list"))
-  (or (cl-find-if (lambda (i) (> i col)) indentations)
-      (when nofail
-        (car (last indentations)))))
-
-(defun mercury-indentation-previous-indentation (col indentations &optional nofail)
-  "Find the rightmost indentation less than COL from INDENTATIONS.
-When no indentations are less than COL, return the rightmost indentation
-if NOFAIL is non-nil, or nil otherwise."
-  (when (null indentations)
-    (error "mercury-indentation-previous-indentation called with empty list"))
-  (let ((rev (reverse indentations)))
-    (or (cl-find-if (lambda (i) (< i col)) rev)
-        (when nofail
-          (car rev)))))
-
+;; TODO
 
 ;; ------------------------------
 ;; Parser starts here

--- a/mercury-indentation.el
+++ b/mercury-indentation.el
@@ -1,12 +1,14 @@
 ;;; mercury-indentation.el --- indentation module for Mercury Mode -*- lexical-binding: t -*-
 
-;; Copyright (C) 2013-2019  Kristof Bastiaensen, Gergely Risko, Ludvig Böklin
+;; Copyright (C) 2013-2019  Kristof Bastiaensen, Gergely Risko, Matthew Carter, Ludvig Böklin
 
 ;; Author: Kristof Bastiaensen <kristof.bastiaensen@vleeuwen.org>
 ;; Author: Gergely Risko <errge@nilcons.com>
+;; Author: Matthew Carter <m@ahungry.com>
 ;; Author: Ludvig Böklin <ludvig.boklin@protonmail.com>
 ;; Keywords: indentation mercury
-;; URL: https://github.com/lboklin/metal-mercury-mode
+;; Maintainer: Matthew Carter <m@ahungry.com>
+;; URL: https://github.com/ahungry/metal-mercury-mode
 
 ;; This file is not part of GNU Emacs.
 

--- a/mercury-indentation.el
+++ b/mercury-indentation.el
@@ -47,7 +47,7 @@
   :group 'mercury
   :prefix "mercury-indentation-")
 
-(defvar mercury-indentation-default-tab-width 2)
+(defvar mercury-indentation-default-tab-width 4)
 
 (defcustom mercury-indentation-electric-flag nil
   "Non-nil means insertion of some characters may auto reindent the line.

--- a/mercury-indentation.el
+++ b/mercury-indentation.el
@@ -147,7 +147,6 @@ if NOFAIL is non-nil, or nil otherwise."
                 (when (looking-at "^[\t ]*),?") ;; on closing paren
                   (progn
                     (when (looking-at "[\t ]*\\(if\\|then\\|else\\).*$")
-                      (message (concat "looking at " (thing-at-point 'line t)))
                       (setq undo-mult 2)))))
               ;; Step back a line and check indent level
               (save-excursion
@@ -166,17 +165,10 @@ if NOFAIL is non-nil, or nil otherwise."
                         (and (looking-at "^[\t ]*(.+$")
                              (not (parens-match '> (thing-at-point 'line t)))))
                     (progn
-                      (message (thing-at-point 'line t))
-                      (message (concat
-                                "prev line was neither inline thing nor unmatched open paren: "
-                                (thing-at-point 'line t)))
                       (setq cur-indent
                             (- (current-indentation)
                                (* undo-mult mercury-indentation-default-tab-width))))
                   (progn
-                    (message (concat
-                              "prev line was inline thing or unmatched open paren: "
-                              (thing-at-point 'line t)))
                     (setq undo-mult 1)
                     (setq cur-indent (current-indentation)))))
               (if (< cur-indent 0)
@@ -187,7 +179,6 @@ if NOFAIL is non-nil, or nil otherwise."
             (forward-line -1)
             (if (looking-at ".*\\. *$") ; Check for rule 3
                 (progn
-                  (message (thing-at-point 'line t))
                   (setq cur-indent 0)
                   (setq not-indented nil))
               ;; Check for rule 4
@@ -216,7 +207,6 @@ if NOFAIL is non-nil, or nil otherwise."
                       ;; else indent.
                       (if (parens-match '< line)
                           (progn
-                            (message "unindent because unmatched ) on prev line")
                             (if (string-match "^[\t ]*),?" line)
                                 (setq cur-indent (current-indentation))
                               (setq cur-indent
@@ -224,7 +214,6 @@ if NOFAIL is non-nil, or nil otherwise."
                                      mercury-indentation-default-tab-width)))
                             (setq not-indented nil))
                         (progn
-                          (message (concat "indent because of indent starter: " line))
                           (setq cur-indent
                                 (+ (current-indentation)
                                    mercury-indentation-default-tab-width))
@@ -234,13 +223,11 @@ if NOFAIL is non-nil, or nil otherwise."
                   ;; but not commented or empty, do not change indent.
                   (when (not (string-match "^[\t ]*\\(%\\|\\)$" line))
                     (progn
-                      (message "retain indentation")
                       (setq cur-indent
                             (current-indentation))
                       (setq not-indented nil))))
                 (if (bobp) ; Check for rule 5
                     (progn
-                      (message "bobp")
                       (setq not-indented nil))))))))
       (if (> cur-indent 0)
           (indent-line-to cur-indent)

--- a/metal-mercury-mode.el
+++ b/metal-mercury-mode.el
@@ -5,7 +5,7 @@
 ;; Author: Ludvig Böklin <ludvig.boklin@protonmail.com>
 ;; Author: Matthew Carter <m@ahungry.com>
 ;; Maintainer: Matthew Carter <m@ahungry.com>
-;; URL: https://github.com/lboklin/metal-mercury-mode
+;; URL: https://github.com/ahungry/metal-mercury-mode
 ;; Version: 0.0.1
 ;; Keywords: ahungry emacs mercury prolog
 ;; Package-Requires: ((emacs "24") (cl-lib "0.5"))

--- a/metal-mercury-mode.el
+++ b/metal-mercury-mode.el
@@ -148,6 +148,11 @@
   (use-local-map metal-mercury-mode-map)
   (set (make-local-variable 'indent-line-function)
        'metal-mercury-mode-indent-line)
+
+  (setq-local comment-start "%")
+  (setq-local comment-end "")
+  (setq-local paragraph-separate "\\(\r\t\n\\|-}\\)$")
+
   (setq major-mode 'metal-mercury-mode)
   (setq mode-name "Mercury")
   (turn-on-mercury-font-lock)

--- a/metal-mercury-mode.el
+++ b/metal-mercury-mode.el
@@ -86,7 +86,9 @@
               ;; Step back a line and check indent level
               (save-excursion
                 (forward-line -1)
-                (setq cur-indent (- (current-indentation) (* undo-mult metal-mercury-mode-default-tab-width)))
+                (setq cur-indent
+                      (- (current-indentation)
+                         (* undo-mult metal-mercury-mode-default-tab-width)))
                 ;;(message (format "unindenting to %s" cur-indent))
                 )
               (if (< cur-indent 0)
@@ -101,13 +103,17 @@
                   (setq cur-indent 0);;(current-indentation))
                   (setq not-indented nil))
               ;; Check for rule 4
-              (if (or (looking-at "^[ \t]*\\(;.*\\|if\\|then\\|else\\)$") ;; End of line matches to indent
-                      (looking-at "^[ \t]*),$") ;; Closing of switch statements
-                      (looking-at "^.*\\(([^)]*\\|\\[[^\\]]*\\|:-\\)$")) ;; Predicate or open paren/bracket
+              ;; End of line matches to indent
+              (if (or (looking-at "^[ \t]*\\(;.*\\|if\\|then\\|else\\)$")
+                      ;; Closing of switch statements
+                      (looking-at "^[ \t]*),$")
+                      ;; Predicate or open paren/bracket
+                      (looking-at "^.*\\(([^)]*\\|{[^}]*\\|\\[[^\\]]*\\|:-\\)$"))
                   (progn
                     (if (looking-at "^[\t ]*),$")
                         (setq cur-indent (current-indentation))
-                      (setq cur-indent (+ (current-indentation) metal-mercury-mode-default-tab-width)))
+                      (setq cur-indent
+                            (+ (current-indentation) metal-mercury-mode-default-tab-width)))
                     (message (thing-at-point 'line t))
                     (setq not-indented nil))
                 (if (bobp) ; Check for rule 5

--- a/metal-mercury-mode.el
+++ b/metal-mercury-mode.el
@@ -43,6 +43,7 @@
 ;; Mode bootstrapped from tutorial here: https://www.emacswiki.org/emacs/ModeTutorial#toc1
 
 (require 'cl-lib)
+(require 'mercury-font-lock)
 
 (defvar metal-mercury-mode-hook nil)
 (defvar metal-mercury-mode-default-tab-width 2)
@@ -60,23 +61,6 @@
     map)
   "Keymap for metal mercury major mode.")
 
-(defconst metal-mercury-mode-font-lock-keywords-1
-  (list
-   '("%.*" . font-lock-comment-face)
-   '("module \\(.+\\)\\." 1 font-lock-doc-face)
-   '("import_module" . font-lock-keyword-face)
-   '("[\t ]*\\(if\\|then\\|else\\|interface\\|pred\\|func\\|module\\|implementation\\)" . font-lock-keyword-face)
-   '("[[:upper:]$]+[[:lower:]_$0-9]*" . font-lock-variable-name-face)
-   '("\\(\\!\\)[[:upper:]$]+[[:lower:]_$]*" 1 font-lock-keyword-face)
-   '("\\.\\([[:lower:]_$]+\\)(" 1 font-lock-negation-char-face)
-   '("\\([[:lower:]_$]+\\.\\)[[:lower:]_$]" 1 font-lock-doc-face)
-   '("\\(\\w+\\)(" 1 font-lock-function-name-face)
-   '("\\(\\w+\\)::" 1 font-lock-type-face)
-   '("::\\(\\w+\\)" 1 font-lock-type-face)
-   '(") is \\(\\w+\\)" 1 font-lock-preprocessor-face)
-   '("[,\\.:-]" . font-lock-negation-char-face)
-   ))
-
 (defun metal-mercury-mode-indent-line ()
   "Indent the current line as mercury code."
   (interactive)
@@ -85,7 +69,7 @@
       (indent-line-to 0) ; Check for rule 1
     (let ((not-indented t) cur-indent)
       ;; Check for rule 2 - End of a block (unindent)
-      (if (looking-at "^[ \t]*\\(;\\|then\\|else\\|)\\)")
+      (if (looking-at "^[ \t]*\\(;.*\\|then\\|else\\|)\\)")
           (progn
             (let ((undo-mult 1))
 
@@ -117,7 +101,7 @@
                   (setq cur-indent 0);;(current-indentation))
                   (setq not-indented nil))
               ;; Check for rule 4
-              (if (or (looking-at "^[ \t]*\\(;\\|if\\|then\\|else\\)$") ;; End of line matches to indent
+              (if (or (looking-at "^[ \t]*\\(;.*\\|if\\|then\\|else\\)$") ;; End of line matches to indent
                       (looking-at "^[ \t]*),$") ;; Closing of switch statements
                       (looking-at "^.*\\((\\|:-\\)$")) ;; Predicate or open paren
                   (progn
@@ -162,12 +146,11 @@
   (kill-all-local-variables)
   (set-syntax-table metal-mercury-mode-syntax-table)
   (use-local-map metal-mercury-mode-map)
-  (set (make-local-variable 'font-lock-defaults)
-       '(metal-mercury-mode-font-lock-keywords-1))
   (set (make-local-variable 'indent-line-function)
        'metal-mercury-mode-indent-line)
   (setq major-mode 'metal-mercury-mode)
-  (setq mode-name "MMM")
+  (setq mode-name "Mercury")
+  (turn-on-mercury-font-lock)
   (run-hooks 'metal-mercury-mode-hook))
 
 ;;;###autoload

--- a/metal-mercury-mode.el
+++ b/metal-mercury-mode.el
@@ -103,7 +103,7 @@
               ;; Check for rule 4
               (if (or (looking-at "^[ \t]*\\(;.*\\|if\\|then\\|else\\)$") ;; End of line matches to indent
                       (looking-at "^[ \t]*),$") ;; Closing of switch statements
-                      (looking-at "^.*\\((\\|:-\\)$")) ;; Predicate or open paren
+                      (looking-at "^.*\\(([^)]*\\|\\[[^\\]]*\\|:-\\)$")) ;; Predicate or open paren/bracket
                   (progn
                     (if (looking-at "^[\t ]*),$")
                         (setq cur-indent (current-indentation))

--- a/metal-mercury-mode.el
+++ b/metal-mercury-mode.el
@@ -108,7 +108,7 @@
                       ;; Closing of switch statements
                       (looking-at "^[ \t]*),$")
                       ;; Predicate or open paren/bracket
-                      (looking-at "^.*\\(([^)]*\\|{[^}]*\\|\\[[^\\]]*\\|:-\\)$"))
+                      (looking-at "^.*\\(([^)]*\\|{[^}]*\\|\\[[^\\]]*\\|:-\\|=\\) *$"))
                   (progn
                     (if (looking-at "^[\t ]*),$")
                         (setq cur-indent (current-indentation))


### PR DESCRIPTION
The tweaks to indentation are of questionable quality (I went in with nearly no experience with elisp) so any feedback is appreciated. I looked into adapting the ident rules from other modes (such as Haskell) but it seemed too big of an undertaking.

In any case, I put syntax highlighting and indent rules into their own separate files, and I'm quite satisfied with the result of the former.